### PR TITLE
Relax upper bound requirements, update setup to use utf8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.19.5
-scipy==1.6.0
-tqdm==4.59.0
-joblib==1.0.1
-pandas==1.3.3
-dill==0.3.4
+numpy>=1.19.5
+scipy>=1.6.0
+tqdm>=4.59.0
+joblib>=1.0.1
+pandas>=1.3.3
+dill>=0.3.4

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open("README_RAW.md", "r") as fh:
+with open("README_RAW.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 with open("requirements.txt") as f:


### PR DESCRIPTION
I am proposing a change to relax required package versions, as they contradict minimal requirements of other commonly used packages (e.g., datasets requires tqdm>=4.62.1, but deepsig requires it to be 4.59.0).

I am also proposing to explicitly specify "utf8" ending for description parsing, as currently Windows system use cp1252 encoding, which throws a parsing error.